### PR TITLE
Solve organize file issue where only 1 subtitles is moved

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.3
+current_version = 2.0.4
 commit = True
 tag = True
 message = bump: {current_version} → {new_version}

--- a/src/nichi/__init__.py
+++ b/src/nichi/__init__.py
@@ -1,6 +1,6 @@
 """Video File Organizer with AI Translation."""
 
-__version__ = "2.0.3"
+__version__ = "2.0.4"
 __author__ = "Rafli"
 __email__ = "hidayattul.rafli@gmail.com"
 __url__ = "https://github.com/hdytrfli/nichi"

--- a/src/nichi/services/jellyfin.py
+++ b/src/nichi/services/jellyfin.py
@@ -46,7 +46,7 @@ class JellyfinParser:
             result["language"] = parts[1]
 
         elif part_count == 3:
-            # name.track.language.srt OR name.language.modifier.srt
+            # Check if the third part is a modifier
             third_part = parts[2]
             if third_part in JellyfinParser.MODIFIERS:
                 # name.language.modifier.srt
@@ -59,23 +59,38 @@ class JellyfinParser:
                 result["track"] = parts[1]
                 result["language"] = third_part
 
-        elif part_count == 4:
-            # name.track.language.modifier.srt
-            result["name"] = parts[0]
-            result["track"] = parts[1]
-            result["language"] = parts[2]
-            result["modifier"] = parts[3]
-
-        elif part_count >= 5:
-            # name.extra.track.language.modifier.srt (language is 3rd from last)
-            language_index = part_count - 3
-            name_end_index = language_index - 1
-            name_parts = parts[:name_end_index]
-            result["name"] = ".".join(name_parts)
-            result["track"] = parts[name_end_index]
-            result["language"] = parts[language_index]
-            modifier_index = language_index + 1
-            result["modifier"] = parts[modifier_index]
+        elif part_count >= 4:
+            # For complex cases, we need to identify the language position
+            # Language is typically the part before the last modifier
+            # or second to last part if there's a modifier
+            
+            # Check if the last part is a modifier
+            last_part = parts[-1]
+            if last_part in JellyfinParser.MODIFIERS:
+                # Has modifier
+                result["modifier"] = last_part
+                # Language is the part before modifier
+                language_index = part_count - 2
+                result["language"] = parts[language_index]
+                # Track is the part before language if there's a track
+                if language_index >= 2:
+                    result["track"] = parts[language_index - 1]
+                    # Name is everything before track
+                    result["name"] = ".".join(parts[:language_index - 1])
+                else:
+                    # No track, name is everything before language
+                    result["name"] = ".".join(parts[:language_index])
+            else:
+                # No modifier, language is the last part
+                result["language"] = last_part
+                # Track is the part before language if there's a track
+                if part_count >= 3:
+                    result["track"] = parts[part_count - 2]
+                    # Name is everything before track
+                    result["name"] = ".".join(parts[:part_count - 2])
+                else:
+                    # No track, name is everything before language
+                    result["name"] = ".".join(parts[:part_count - 1])
 
         return result
 

--- a/tests/test_jellyfin_organizer.py
+++ b/tests/test_jellyfin_organizer.py
@@ -31,12 +31,12 @@ def test_jellyfin_naming_support():
         assert isinstance(base_name, str) and len(base_name) > 0, f"Base name extraction failed for {subtitle_filename}"
 
     # Test match_subtitle_to_video with matching names
-    matched_subtitle = organizer.match_subtitle_to_video("movie.mp4", ["movie.eng.srt"])
-    assert matched_subtitle == "movie.eng.srt", "Should match movie.mp4 with movie.eng.srt"
+    matched_subtitles = organizer.match_subtitle_to_video("movie.mp4", ["movie.eng.srt"])
+    assert matched_subtitles == ["movie.eng.srt"], "Should match movie.mp4 with movie.eng.srt"
 
     # Test match_subtitle_to_video with non-matching names
-    matched_subtitle = organizer.match_subtitle_to_video("movie.mp4", ["different.eng.srt"])
-    assert matched_subtitle is None, "Should not match movie.mp4 with different.eng.srt"
+    matched_subtitles = organizer.match_subtitle_to_video("movie.mp4", ["different.eng.srt"])
+    assert matched_subtitles == [], "Should not match movie.mp4 with different.eng.srt"
 
     print("Jellyfin naming convention tests passed!")
 
@@ -77,7 +77,30 @@ def test_find_subtitle_files():
         print("Subtitle file detection test passed!")
 
 
+def test_multiple_subtitles_per_video():
+    """Test that the organizer can handle multiple subtitles for the same video."""
+    organizer = FileOrganizer()
+    
+    # Test matching multiple subtitles to one video
+    subtitle_files = [
+        "movie.eng.srt",
+        "movie.ind.srt", 
+        "movie.eng.sdh.srt"
+    ]
+    
+    matched_subtitles = organizer.match_subtitle_to_video("movie.mp4", subtitle_files)
+    assert len(matched_subtitles) == 3, "Should match all three subtitles to movie.mp4"
+    
+    # All should have the same base name "movie"
+    for subtitle in matched_subtitles:
+        base_name = organizer.extract_base_name(subtitle)
+        assert base_name == "movie", f"Subtitle {subtitle} should have base name 'movie'"
+        
+    print("Multiple subtitles per video test passed!")
+
+
 if __name__ == "__main__":
     test_jellyfin_naming_support()
     test_find_subtitle_files()
+    test_multiple_subtitles_per_video()
     print("All tests passed!")

--- a/tests/test_subtitle_organization.py
+++ b/tests/test_subtitle_organization.py
@@ -1,0 +1,43 @@
+"""Test for subtitle organization fix."""
+
+import os
+import tempfile
+import shutil
+from nichi.core.organizer import FileOrganizer
+
+
+def test_subtitle_organization_fix():
+    """Test that all subtitle files are moved with their video."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Create test files as described in the issue
+        test_files = [
+            "example.mp4",
+            "example.en.srt",  # English subtitle
+            "example.id.srt",  # Indonesian subtitle
+            "example.en.sdh.srt"  # English SDH subtitle
+        ]
+
+        for filename in test_files:
+            file_path = os.path.join(temp_dir, filename)
+            with open(file_path, "w") as f:
+                f.write("test content")
+
+        # Run the organizer
+        organizer = FileOrganizer()
+        result = organizer.organize_directory(temp_dir)
+        
+        # Check that a folder was created
+        expected_folder = os.path.join(temp_dir, "example")
+        assert os.path.exists(expected_folder), "Folder 'example' should be created"
+        
+        # Check that all files were moved to the folder
+        for filename in test_files:
+            file_path = os.path.join(expected_folder, filename)
+            assert os.path.exists(file_path), f"File {filename} should be moved to the folder"
+            
+        print("Subtitle organization fix test passed!")
+
+
+if __name__ == "__main__":
+    test_subtitle_organization_fix()
+    print("All tests passed!")


### PR DESCRIPTION
### Description
This PR fixes an issue where the file organizer was only moving one subtitle file per video instead of all matching subtitles. It also resolves a problem where `.en.sdh.srt` files were being preferred over other subtitles like `.en.srt` and `.id.srt`.

### Changes
- Modified the file organizer to handle multiple subtitles per video
- Improved Jellyfin parser logic to correctly identify all subtitle naming patterns
- All matching subtitles now moved to the same folder with their video

### Testing
- Added new tests to verify multiple subtitle handling
- All existing tests continue to pass
- Tested with various Jellyfin subtitle naming conventions

### Related Issue
Closes #3 issue